### PR TITLE
Bookモデルに、販売状況を示すEnumを追加

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,4 +1,10 @@
 class Book < ApplicationRecord
+  enum sales_status: {
+    reservation:  0, # 予約受付
+    now_on_sale:  1, # 発売中
+    end_of_print: 2  # 販売終了
+  }
+
   scope :costly, -> { where('price > ?', 3000) }
   scope :wirtten_about, ->(theme) { where('name like ?', "%#{theme}%") }
 

--- a/db/migrate/20240901084225_add_status_to_books.rb
+++ b/db/migrate/20240901084225_add_status_to_books.rb
@@ -1,0 +1,5 @@
+class AddStatusToBooks < ActiveRecord::Migration[6.0]
+  def change
+    add_column :books, :sales_status, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_08_31_120155) do
+ActiveRecord::Schema.define(version: 2024_09_01_084225) do
 
   create_table "authors", force: :cascade do |t|
     t.string "name"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 2024_08_31_120155) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "publisher_id", null: false
+    t.integer "sales_status"
     t.index ["publisher_id"], name: "index_books_on_publisher_id"
   end
 


### PR DESCRIPTION
# 概要
Bookモデルに、販売状況に関するステータスを追加する

販売状況はテーブル定義の観点で言えば十分に少ない個数のバリエーションのため、文字列として保存するのではなく数値で扱う方が効率的

# ActiveRecord::Enumで列挙型を扱う
- 列挙型や、enum型と呼ばれる
- ActiveRecordが提供するenum型は、数値のカラムに対してプログラム上で扱える別名を与える

```
$ rails g migration AddStatusToBooks sales_status:integer
$ rails db:migrate
```

```
class Book < ApplicationRecord
  enum sales_status: {
    reservation:  0, # 予約受付
    now_on_sale:  1, # 発売中
    end_of_print: 2  # 販売終了
  }
  
  # 省略
end
```


# Enumで定義された状態の確認
```
target_book = Book.last
target_book.now_on_sale?  # => true
target_book.end_of_print? # => false

target_book.end_of_print! # commit transaction
target_book.end_of_print? # => true

target_book.sales_status  # => "end_of_print"

# DBに保存されている実際の値を確認
target_book.sales_status_before_type_cast # => 2

Book.sales_statuses       # => {"reservation"=>0, "now_on_sale"=>1, "end_of_print"=>2}
```

# Enumを導入すると利用できるScope
enum型の名称で検索するためのscopeも追加される。
- 該当するenum名で検索するscope
- 該当enum名を含まない検索

```
Book.now_on_sale
Book.not_now_on_sale
```

# ActiveRecord::Enumとenumerize
Railsでは4.1からActiveRecord::Enumという組み込みのEnum機能が導入された。
一方、それ以前から利用されているgemとしてenumerizeがある。
https://github.com/brainspec/enumerize （こちらの方がより高機能）

利用を検討するのも良さそう